### PR TITLE
Projection plot for multiple indicators

### DIFF
--- a/grade.js
+++ b/grade.js
@@ -821,7 +821,7 @@ function getErrorTextFromPictogramData(errors){
 
 function getPictogramReadyData()
 {
-    var projectionData = getProjectionDataForAllStandardPopulationOutcomes();
+    var projectionData = getPictogramProjectionData();
     return convertProjectionDataToPictogramData(projectionData);
     }
 
@@ -836,34 +836,38 @@ function convertProjectionDataToPictogramData(data){
 	    errorList.push(outcomeData.data.error);
 	});
 
-    for (var i = 0; i < numberOfAdditionalResults; i++){
-        var categories = [];
-        var finalResults = [];
-        var name;
+    var categories = [];
+    var finalResults = [];
+    var name;
+
+    var barColour = d3.scale.linear().
+        domain([0, 1E5]).
+	range(["#dee5f8", "#e09900"]).
+	interpolate(d3.interpolateLab);
 
         data.forEach(function(outcomeData, outcomeIndex){
-	    categories.push(outcomeData.outcome.name);
             var thisOutcomeDataSeries = outcomeData.data.data;
             var finalResultThisOutcomeDataSeries = thisOutcomeDataSeries[thisOutcomeDataSeries.length - 1];
-            const value = finalResultThisOutcomeDataSeries.additional[i].value.toFixed(0);
+            const value = finalResultThisOutcomeDataSeries.additional[0].value.toFixed(0);
             finalResults.push(value);
-            populationName = finalResultThisOutcomeDataSeries.additional[i].populationName;
+            populationName = finalResultThisOutcomeDataSeries.additional[0].populationName;
+	    categories.push(finalResultThisOutcomeDataSeries.additional[0].name);
             csvData.push({
        	                value : value,
-			name : finalResultThisOutcomeDataSeries.additional[i].name,
+			name : finalResultThisOutcomeDataSeries.additional[0].name,
 			});
         });
 
         var plotObject = {
 	    name: populationName, 
 	    y: categories, 
-	    x: finalResults, 
+	    x: finalResults,
+	    marker:{color:finalResults.map(barColour)},
 	    type: 'bar', 
 	    orientation:'h',
 	    hoverlabel: {namelength :-1},
 	};
         plotObjectList.push(plotObject);
-    }
 
     return {
 	plotData: plotObjectList,
@@ -872,15 +876,29 @@ function convertProjectionDataToPictogramData(data){
 	    };
 }
 
-function getProjectionDataForAllStandardPopulationOutcomes()
+
+
+function getPictogramProjectionData()
 {
     var projectionData = [];
-    outcomesList.forEach(function (o){
-        const [outcomeName, outcomeObject] = o;
-        if (outcomeName != "$-ALL" && outcomeObject.isStandardPopulationIndicator){
+
+    keysOfOutcomesToShow = [
+			    "U5MSURV",
+			    "PRIMARYSCHOOL",
+			    "LOWERSCHOOL",
+			    "UPPERSCHOOL",
+			    "Stunting prevalence (% of population)",
+			    "Access to electricity (% of population)",
+			    "WATERBASIC",
+			    "SANITBASIC",
+			    "Access to clean fuels and technologies for cooking (% of population)"
+			    ];
+
+    keysOfOutcomesToShow.reverse().forEach(function (outcomeName){
+            var outcomeObject = outcomesMap.get(outcomeName);
             var thisOutcomeProjectionData = getProjectionData(+year, country, outcomeName, +years_to_project, getRevenueInputs(), getGovernanceInputs(), smooth);
 	    projectionData.push({outcome:outcomeObject, data:thisOutcomeProjectionData});
-	}});
+	});
 
     return projectionData;
 }

--- a/grade.js
+++ b/grade.js
@@ -169,15 +169,15 @@ function getGovernanceInputs(){
 }
 
 function getColor(_cid, _year, _revenue, _governance) {
+
+    var value;
     if (allIndicatorsSelected()){
-        // When all indicators are selected, get the colour corresponding to GRPC
-        let revenues = getRevenue(_cid, _year, _revenue);
-        if (revenues === undefined){
-            return NaN;
-        }
-        return colorScale(revenues["new grpc"]);
+	var revenues = getRevenue(_cid, _year, _revenue);
+        value = revenues === undefined ? NaN : revenues["new grpc"];
     }
-    var value = getResult(_cid, _year, _revenue, _governance);
+    else {
+	value = getResult(_cid, _year, _revenue, _governance);
+    }
         
     if (!isNaN(value)) {
         if (multipleCountriesSelected())
@@ -199,7 +199,7 @@ function getColor(_cid, _year, _revenue, _governance) {
             return colorScale(value);
         }
     }
-        else {
+    else {
         return "rgba(0, 0, 0, 0.6)";
     }
 }

--- a/grade.js
+++ b/grade.js
@@ -845,7 +845,7 @@ function convertProjectionDataToPictogramData(data){
 	range(["#dee5f8", "#e09900"]).
 	interpolate(d3.interpolateLab);
 
-        data.forEach(function(outcomeData, outcomeIndex){
+    data.forEach(function(outcomeData, outcomeIndex){
             var thisOutcomeDataSeries = outcomeData.data.data;
             var finalResultThisOutcomeDataSeries = thisOutcomeDataSeries[thisOutcomeDataSeries.length - 1];
             const value = finalResultThisOutcomeDataSeries.additional[0].value.toFixed(0);
@@ -857,6 +857,9 @@ function convertProjectionDataToPictogramData(data){
 			name : finalResultThisOutcomeDataSeries.additional[0].name,
 			});
         });
+
+    categories = categories.reverse();
+    finalResults = finalResults.reverse();
 
         var plotObject = {
 	    name: populationName, 
@@ -894,7 +897,7 @@ function getPictogramProjectionData()
 			    "Access to clean fuels and technologies for cooking (% of population)"
 			    ];
 
-    keysOfOutcomesToShow.reverse().forEach(function (outcomeName){
+    keysOfOutcomesToShow.forEach(function (outcomeName){
             var outcomeObject = outcomesMap.get(outcomeName);
             var thisOutcomeProjectionData = getProjectionData(+year, country, outcomeName, +years_to_project, getRevenueInputs(), getGovernanceInputs(), smooth);
 	    projectionData.push({outcome:outcomeObject, data:thisOutcomeProjectionData});

--- a/grade.js
+++ b/grade.js
@@ -258,18 +258,17 @@ function makeText(_iso, _year, _revenue, _governance) {
         return "<strong>" + countrycodes.get(_iso) + "<\/strong>" + ": No GRPC data available";
     }
     var result;
-    var coverageDescriptor;
-    var dp;
+    var coverageDescriptor="";
+    var dp=0;
 
     // Only compute the results if an indicator is selected
     if (!allIndicatorsSelected()){
         result = computeResult(_iso, _year, outcome, revenues["new grpc"], revenues["historical grpc"], _governance);
+	coverageDescriptor = outcomesMap.get(outcome).isPercentage ? "% coverage" : "coverage ratio";
+	dp = outcomesMap.get(outcome).dp;
         if (result.error)
         {
             return "<strong>" + countrycodes.get(_iso) + "<\/strong>" + ": " + result.error.join("<br>");
-	    coverageDescriptor = outcomesMap.get(outcome).isPercentage ? "% coverage" : "c\
-overage ratio";
-	    dp = outcomesMap.get(outcome).dp;
         }
     }
     var text = "";
@@ -829,7 +828,6 @@ function getPictogramReadyData()
 function convertProjectionDataToPictogramData(data){
 
     var plotObjectList = [];
-    var numberOfAdditionalResults = 3;
     var csvData = [];
     var errorList = [];
 
@@ -839,8 +837,6 @@ function convertProjectionDataToPictogramData(data){
 
     var categories = [];
     var finalResults = [];
-    var name;
-
     var barColour = d3.scale.linear().
         domain([0, 1E5]).
 	range(["#dee5f8", "#e09900"]).

--- a/grade.js
+++ b/grade.js
@@ -776,12 +776,12 @@ function convertPictogramDataToCsvString(data){
 }
 
 function download_csv_pictogram(){
-    let data = getPictogramDataForCsvDownload();
+    let dataObject = getPictogramReadyData();
+    let data = dataObject.csvData;
     let csvdata = convertPictogramDataToCsvString(data);
     let finalYear = +year + years_to_project;
 
     var button_title =  country + "_" + year + "-" + finalYear + ".csv";
-    console.log(csvdata);
     if (csvdata)
 	{
 	    var hiddenElement = document.createElement('a');
@@ -802,21 +802,21 @@ function updatePictogram(){
         d3.select("#pictogram-wrapper").style("display", "inline-block");
     }
 
-    var dataToPlot = getPictogramDataToPlot();
+    var data = getPictogramReadyData();
     var layout = {yaxis:{automargin:true}};
 
-    Plotly.newPlot('pictogram', dataToPlot, layout);
-    
+    Plotly.newPlot('pictogram', data.plotData, layout);    
+
+    var errorText = getErrorTextFromPictogramData(data.error);
+    var text = countrycodes.get(country);
+    if (errorText.length > 0){
+	text += ": " + errorText;
+    }
+    d3.select("#pictogram-errors").html(text);
 }
 
-function getPictogramDataToPlot(){
-    var pictogramReadyData = getPictogramReadyData();
-    return pictogramReadyData.plotData;
- }
-
-function getPictogramDataForCsvDownload(){
-    var pictogramReadyData = getPictogramReadyData();
-    return pictogramReadyData.csvData;
+function getErrorTextFromPictogramData(errors){
+    return errors.filter(e => e !== null && e.length > 0).length > 0 ? "Unable to calculate some results (e.g. due to missing data)" : "";
 }
 
 function getPictogramReadyData()
@@ -830,6 +830,11 @@ function convertProjectionDataToPictogramData(data){
     var plotObjectList = [];
     var numberOfAdditionalResults = 3;
     var csvData = [];
+    var errorList = [];
+
+    data.forEach(outcomeData => { 
+	    errorList.push(outcomeData.data.error);
+	});
 
     for (var i = 0; i < numberOfAdditionalResults; i++){
         var categories = [];
@@ -860,7 +865,11 @@ function convertProjectionDataToPictogramData(data){
         plotObjectList.push(plotObject);
     }
 
-    return {plotData: plotObjectList, csvData: csvData};
+    return {
+	plotData: plotObjectList,
+	csvData: csvData, 
+        error: errorList,
+	    };
 }
 
 function getProjectionDataForAllStandardPopulationOutcomes()

--- a/grade.js
+++ b/grade.js
@@ -1,3 +1,4 @@
+
 var version = "GRADE v3.15.6"
 var date = "2025/02/19"
 var subheight = 100;
@@ -780,7 +781,7 @@ function download_csv_pictogram(){
     let csvdata = convertPictogramDataToCsvString(data);
     let finalYear = +year + years_to_project;
 
-    var button_title =  +year + "-" + finalYear + "_" + country + ".csv";
+    var button_title =  country + "_" + year + "-" + finalYear + ".csv";
     console.log(csvdata);
     if (csvdata)
 	{

--- a/grade.js
+++ b/grade.js
@@ -761,8 +761,35 @@ function buildOutcomeDataSeries(data, resultToPlot, property, i, linetype)
     return outcomedata;
 }
 
+function convertPictogramDataToCsvString(data){
+    var str = "";
+    data.forEach(function(item){
+	    str += item.name + ","
+	});
+    str = str.slice(0, str.length - 1) + "\n";
+    data.forEach(function(item){
+	    str += item.value + ","
+	})
+    str = str.slice(0, str.length - 1);
+
+    return str;
+}
+
 function download_csv_pictogram(){
-    console.log("hi");
+    let data = getPictogramDataForCsvDownload();
+    let csvdata = convertPictogramDataToCsvString(data);
+    let finalYear = +year + years_to_project;
+
+    var button_title =  +year + "-" + finalYear + "_" + country + ".csv";
+    console.log(csvdata);
+    if (csvdata)
+	{
+	    var hiddenElement = document.createElement('a');
+	    hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csvdata);
+	    hiddenElement.target = '_blank';
+	    hiddenElement.download = button_title;
+	    hiddenElement.click();
+	}
 }
 
 function updatePictogram(){
@@ -783,15 +810,26 @@ function updatePictogram(){
 }
 
 function getPictogramDataToPlot(){
+    var pictogramReadyData = getPictogramReadyData();
+    return pictogramReadyData.plotData;
+ }
 
+function getPictogramDataForCsvDownload(){
+    var pictogramReadyData = getPictogramReadyData();
+    return pictogramReadyData.csvData;
+}
+
+function getPictogramReadyData()
+{
     var projectionData = getProjectionDataForAllStandardPopulationOutcomes();
     return convertProjectionDataToPictogramData(projectionData);
- }
+    }
 
 function convertProjectionDataToPictogramData(data){
 
     var plotObjectList = [];
     var numberOfAdditionalResults = 3;
+    var csvData = [];
 
     for (var i = 0; i < numberOfAdditionalResults; i++){
         var categories = [];
@@ -802,13 +840,17 @@ function convertProjectionDataToPictogramData(data){
 	    categories.push(outcomeData.outcome.name);
             var thisOutcomeDataSeries = outcomeData.data.data;
             var finalResultThisOutcomeDataSeries = thisOutcomeDataSeries[thisOutcomeDataSeries.length - 1];
-            finalResults.push(finalResultThisOutcomeDataSeries.additional[i].value);
-            name = finalResultThisOutcomeDataSeries.additional[i].populationName;
+            const value = finalResultThisOutcomeDataSeries.additional[i].value.toFixed(0);
+            finalResults.push(value);
+            populationName = finalResultThisOutcomeDataSeries.additional[i].populationName;
+            csvData.push({
+       	                value : value,
+			name : finalResultThisOutcomeDataSeries.additional[i].name,
+			});
         });
 
-
         var plotObject = {
-	    name: name, 
+	    name: populationName, 
 	    y: categories, 
 	    x: finalResults, 
 	    type: 'bar', 
@@ -818,7 +860,7 @@ function convertProjectionDataToPictogramData(data){
         plotObjectList.push(plotObject);
     }
 
-  return plotObjectList;
+    return {plotData: plotObjectList, csvData: csvData};
 }
 
 function getProjectionDataForAllStandardPopulationOutcomes()

--- a/grade.js
+++ b/grade.js
@@ -693,7 +693,7 @@ function updateCountries() {
     var d = {
         "id": country
     };
-    if (true){ // set true to show instantaneous box
+    if (false){ // set true to show instantaneous box //!!
         var text = getText(d, true, getRevenueInputs(), +year, getGovernanceInputs(), smooth);
         d3.select("#countrytext").
         html(text);
@@ -702,6 +702,7 @@ function updateCountries() {
     }
     colourCountries();
     updateplot();
+    updatePictogram();
     updatetarget();
 }
 
@@ -737,7 +738,19 @@ function buildOutcomeDataSeries(data, resultToPlot, property, i, linetype)
     return outcomedata;
 }
 
+function updatePictogram(){
+    if (country.slice(0, 2) == "$-") {
+            d3.select("#pictogram-wrapper").style("display", "none");
+        return;
+    }
+    d3.select("#pictogram-wrapper").style("display", "inline-block");
+}
+
 function updateplot() {
+
+    //!!
+    return;
+
     if (country.slice(0, 2) == "$-") {
         d3.select("#plotwrapper").style("display", "none");
     } else {

--- a/grade.js
+++ b/grade.js
@@ -808,7 +808,8 @@ function updatePictogram(){
     Plotly.newPlot('pictogram', data.plotData, layout);    
 
     var errorText = getErrorTextFromPictogramData(data.error);
-    var text = countrycodes.get(country);
+    let finalYear = +year + years_to_project;
+    var text = countrycodes.get(country) + `: final effects in ${finalYear}`;
     if (errorText.length > 0){
 	text += ": " + errorText;
     }

--- a/index.html
+++ b/index.html
@@ -298,6 +298,8 @@
                     </p>
                 </div>
                 -->
+            <div id="pictogram-wrapper" class="plotwrapper">
+            </div>
             <div class="plotwrapper" id="plotwrapper">
                 <div class="plot" id="plot">
                     <!---
@@ -305,6 +307,7 @@
                         </select>
                     -->
                 </div>
+		
                 <div class="plottools">
                     <label class="container">
                         Plot population result

--- a/index.html
+++ b/index.html
@@ -289,9 +289,16 @@
                 </div>
                 -->
             <div id="pictogram-wrapper" class="plotwrapper">
-	    <p>Pictogram placeholder</p>
+	      <h2>People with increased access</h2>
+	      <div id="pictogram" class="plot">
+	      </div>
+
+                    <button onclick="download_csv_pictogram()"><i class="fa fa-download"></i>&nbsp;Download plot data</button>
+                    <button onclick="reset(event)"><i class="fa fa-close"></i>&nbsp;Close</button>
+
             </div>
             <div class="plotwrapper" id="plotwrapper">
+	        <h2>Projection results</h2>
                 <div class="plot" id="plot">
                     <!---
                     Result to show <select id="countrylist" name="country">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <script src="https://d3js.org/d3.v3.min.js"></script>
     <script src="https://d3js.org/queue.v1.min.js"></script>
     <script src="https://d3js.org/topojson.v1.min.js"></script>
-    <script src='https://cdn.plot.ly/plotly-latest.min.js'></script>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.js"></script>
     <script src="tooltip.js"></script>
     <script src="d3-legend.min.js"></script>
@@ -205,16 +205,6 @@
                             </select>
                             <div class="filteroptions" id="countryfilter">
                             </div>
-                            <label class="container">
-                                Selected outcome
-                                <input type="radio" id="multioutcomethis" name="multi csv outcome" value="THIS" checked>
-                                <span class="checkmark"></span>
-                            </label>
-                            <label class="container">
-                                All outcomes
-                                <input type="radio" id="multioutcomeall" name="multi csv outcome" value="ALL">
-                                <span class="checkmark"></span>
-                            </label>
                             <button id="multibutton" onclick="download_csv_multi()"><i
                                     class="fa fa-download"></i>&nbsp;Download projection data</button>
                             <button id="clearmultibutton" onclick="clear_multi()"><i class="fa fa-trash"></i>&nbsp;Clear
@@ -247,7 +237,7 @@
                     <div class="uiouter">
                         <p>Set target <span id="targetVal"></span></p>
                         <div class="uicontainer">
-                            <input type="text" name="targetInput" id="targetInput" class="numeric" value="100">
+                            <input disabled type="text" name="targetInput" id="targetInput" class="numeric" value="100">
                             <label id="targetLabel" for="targetInput">%</label>
                             <div id="targetText">No country selected</div>
                         </div>
@@ -299,6 +289,7 @@
                 </div>
                 -->
             <div id="pictogram-wrapper" class="plotwrapper">
+	    <p>Pictogram placeholder</p>
             </div>
             <div class="plotwrapper" id="plotwrapper">
                 <div class="plot" id="plot">
@@ -321,7 +312,7 @@
                     </label>
                     <button onclick="download_csv_plot()"><i class="fa fa-download"></i>&nbsp;Download plot
                         data</button>
-                    <button onclick="reset()"><i class="fa fa-close"></i>&nbsp;Close</button>
+                    <button onclick="reset(event)"><i class="fa fa-close"></i>&nbsp;Close</button>
                     <!---
                         <select name="plottype" id="plottype">
                             <option value="u5m">Under-5 deaths averted</option>
@@ -458,7 +449,7 @@
             }
         }
 
-        function reset() {
+        function reset(e) {
             //active.classed("active", false);
             //active = d3.select(null);
 
@@ -468,7 +459,12 @@
             d3.select('#countrylist').property('value', "$-ALL");
             mainUpdate();
 
-            d3.event.stopPropagation();
+	    if (typeof e !== 'undefined'){
+                e.stopPropagation();
+            }
+            else{
+                d3.event.stopPropagation();
+            }
         }
 
         function resetview() {

--- a/index.html
+++ b/index.html
@@ -290,6 +290,7 @@
                 -->
             <div id="pictogram-wrapper" class="plotwrapper">
 	      <h2>People with increased access</h2>
+              <p id="pictogram-errors"></p>
 	      <div id="pictogram" class="plot">
 	      </div>
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <script src="https://d3js.org/d3.v3.min.js"></script>
     <script src="https://d3js.org/queue.v1.min.js"></script>
     <script src="https://d3js.org/topojson.v1.min.js"></script>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js" charset="utf-8"></script>
+    <script src="https://cdn.plot.ly/plotly-3.0.1.min.js" charset="utf-8"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.js"></script>
     <script src="tooltip.js"></script>
     <script src="d3-legend.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
                 </div>
                 -->
             <div id="pictogram-wrapper" class="plotwrapper">
-	      <h2>People with increased access</h2>
+	      <h2>Effects for multiple indicators</h2>
               <p id="pictogram-errors"></p>
 	      <div id="pictogram" class="plot">
 	      </div>

--- a/model.js
+++ b/model.js
@@ -23,6 +23,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target: 100,
 	    dp:2,
             coeffs : new Map(
@@ -65,6 +66,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target: 100,
 	    dp:2,
             coeffs : new Map(
@@ -112,6 +114,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target: 100,
 	    dp:2,
             coeffs : new Map(
@@ -164,6 +167,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target: 100,
 	    dp:2,
             coeffs : new Map(
@@ -209,6 +213,7 @@ var outcomesList = [
             isStockVar : false,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: false,
             target: 99.9, // upper limit of mortality of 1 in 1000
 	    dp:2,
             coeffs : new Map(
@@ -255,6 +260,7 @@ var outcomesList = [
             isStockVar : false,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: false,
             target: 100,
 	    dp:2,
             coeffs : new Map(
@@ -304,6 +310,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target: 1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -361,6 +368,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target: 1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -418,6 +426,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target: 1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -466,6 +475,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target:0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -518,6 +528,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target: 0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -571,6 +582,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isStandardPopulationIndicator: false,
             target:0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -624,6 +636,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target:100,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -668,6 +681,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: true,
             target:100,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -707,6 +721,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
+	    isStandardPopulationIndicator: false,
             target:100,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -846,14 +861,19 @@ function computeAdditionalResults(_iso, _year, _outcome, improved, original){
     var popChildrenSurvive1 = popdata.getvalue(_iso, _year, "Children survive to 1 year");
     var popBirths = popdata.getvalue(_iso, _year, "Number of births")
     var popChildrenSurvive5 = popdata.getvalue(_iso, _year, "Number of children surviving to five");
-    let outcomeName = outcomesMap.get(_outcome).name
+    const outcomeObject = outcomesMap.get(_outcome);
+    const outcomeName = outcomeObject.name;
+    const peopleText = "People";
+    const childrenText = "Children < 5";
+    const femalesText = "Females 15-49";
+    const withIncreasedAccessTo = " with increased access to ";
 
     var additional = [];
 
-    if (_outcome == "SANITBASIC" || _outcome == "SANITSAFE" || _outcome == "WATERBASIC" || _outcome == "WATERSAFE" || _outcome == "Access to clean fuels and technologies for cooking (% of population)" || _outcome == "Access to electricity (% of population)") {
-        additional.push({name : "People with increased access to " + outcomeName,  value : (improved - original) / 100 * popTotal, keyvariable : true});
-        additional.push({name : "Children < 5 with increased access to " + outcomeName, value : (improved - original) / 100 * popU5, keyvariable : true});
-        additional.push({name : "Females 15-49 with increased access to " + outcomeName, value: (improved - original) / 100 * popFemale15_49, keyvariable : true});
+    if (outcomeObject.isStandardPopulationIndicator) {
+        additional.push({name : peopleText + withIncreasedAccessTo + outcomeName,  value : (improved - original) / 100 * popTotal, keyvariable : true, populationName : peopleText});
+        additional.push({name : childrenText + withIncreasedAccessTo + outcomeName, value : (improved - original) / 100 * popU5, keyvariable : true, populationName : childrenText});
+        additional.push({name : femalesText + withIncreasedAccessTo + outcomeName, value: (improved - original) / 100 * popFemale15_49, keyvariable : true, populationName : femalesText});
     } else if (_outcome == "IMUNISATION") {
         additional.push({name : "Number of infants immunised", value : (improved - original) / 100 * popChildrenSurvive1, keyvariable : true})
     } else if (_outcome == "SCHOOLPERC") {

--- a/model.js
+++ b/model.js
@@ -1,5 +1,18 @@
 // **** add or update outcomes here ****
 var outcomesList = [
+	["$-ALL",
+        {
+            name: "All indicators",
+	    loCol: "#dee5f8",
+            hiCol: "#e09900",
+            fixedExtent: [0, 10000],
+            desc: "Government revenue per capita (improved)",
+            isStockVar : true,
+            isInterpolated : false,
+            isPercentage: true,
+            target: 100,
+            dp:2,
+            }],
         ["WATERBASIC",
         {
             name: "Basic water (SDG 6)",

--- a/model.js
+++ b/model.js
@@ -2,7 +2,7 @@
 var outcomesList = [
 	["$-ALL",
         {
-            name: "All indicators",
+            name: "Multiple indicators",
 	    loCol: "#dee5f8",
             hiCol: "#e09900",
             fixedExtent: [0, 10000],

--- a/style.css
+++ b/style.css
@@ -61,6 +61,10 @@ p {
     pointer-events: all;
 }
 
+#pictogram-wrapper {
+    width: 50%;
+}
+
 #ploterror {
     display: none;
     margin-top: 10px;

--- a/style.css
+++ b/style.css
@@ -25,6 +25,10 @@ p {
     margin-block-end: 0px;
 }
 
+#pictogram-errors{
+    font-size: 100%;
+}
+
 .output {
     font-size: 100%;
     white-space: normal;

--- a/style.css
+++ b/style.css
@@ -62,7 +62,7 @@ p {
 }
 
 #pictogram-wrapper {
-    width: 90%;
+    width: 80%;
     pointer-events: all;
 }
 

--- a/style.css
+++ b/style.css
@@ -62,7 +62,8 @@ p {
 }
 
 #pictogram-wrapper {
-    width: 50%;
+    width: 90%;
+    pointer-events: all;
 }
 
 #ploterror {
@@ -111,7 +112,7 @@ vis {
 
 #countrydata,
 #countrydata2,
-#plotwrapper {
+#plotwrapper, #pictogram-wrapper {
     margin-top: 10px;
     margin-left: 10px;
     vertical-align: top;


### PR DESCRIPTION
** Background **
Feature to view the effects on multiple indicators simultaneously as a bar chart. This is achieved by adding an additional "multiple indicators" option to the outcome dropdown; when selected, the map shows GRPC, while if a country is selected, the results for the final year of a projection are shown for a group of indicators

**Changes**
* Add multiple indicators option to outcome dropdown and show bar chart when a country is selected and GRPC on the map
* Show an error message when a result is unavailable
* Add accompanying CSV 
* Update Plotly to use latest version