### PR TITLE
Alert user if observed coverage saturates

### DIFF
--- a/grade.js
+++ b/grade.js
@@ -749,6 +749,14 @@ function updateplot() {
         }
         
         var data = plotdata.data;
+
+	// call out if base coverage reaches 100%
+	let outcomeObject = outcomesMap.get(outcome);
+	d3.select("#plot-errors").html("");
+	if (data.some(d => hasCoverageValueReachedSaturation(d.coverage[0].value, outcomeObject))){
+	    d3.select("#plot-errors").html(getCoverageSaturationWarningText(outcomeObject))
+	}
+
         var dataFromObservation = data.filter(x => x.year <= startingYearOfExtensions)
         var dataExtended = data.filter(x => x.year >= startingYearOfExtensions)
         var x_annotation = plotdata.start_of_effect;

--- a/index.html
+++ b/index.html
@@ -299,6 +299,7 @@
                 </div>
                 -->
             <div class="plotwrapper" id="plotwrapper">
+	        <p id="plot-errors"></p>
                 <div class="plot" id="plot">
                     <!---
                     Result to show <select id="countrylist" name="country">

--- a/model.js
+++ b/model.js
@@ -453,6 +453,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isNonSaturating: true,
             target:0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -505,6 +506,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isNonSaturating: true,
             target: 0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -558,6 +560,7 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
+	    isNonSaturating: true,
             target:0.1,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
@@ -694,7 +697,8 @@ var outcomesList = [
             isStockVar : true,
             isInterpolated : false,
             isPercentage: true,
-            target:100,
+            target:0,
+	    isNegativeDeltaImprovement: true,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
                 g = _type => getGov(_type, _iso, _year, _gov, _grpc);
@@ -1176,4 +1180,41 @@ function getRevenue(_iso, _year, _revenue) {
     }
 
     return ret;
+}
+
+function hasCoverageValueReachedSaturation(value, outcomeObject)
+{
+    if (outcomeObject.hasOwnProperty("isNonSaturating") && outcomeObject.isNonSaturing){
+	return false;
+    }
+    if (outcomeObject.hasOwnProperty("isNegativeDeltaImprovement") && outcomeObject.isNegativeDeltaImprovement){
+	return  value <= outcomeObject.target;
+    }
+    else{
+	return value >= outcomeObject.target;
+    }
+}
+
+function getCoverageSaturationWarningText(outcomeObject)
+{
+    var text = "";
+
+    if (outcomeObject.hasOwnProperty("isNonSaturating") && outcomeObject.isNonSaturing){
+        return text;
+    }
+
+    var maxOrMin = "";
+    var hasWarning = false;
+
+    if (outcomeObject.hasOwnProperty("isNegativeDeltaImprovement") && outcomeObject.isNegativeDeltaImprovement){
+	    var maxOrMin = "minimum";
+    }
+    else{
+	    var maxOrMin = "maximum";
+    }
+
+    var targetText = `${outcomeObject.target}${outcomeObject.isPercentage ? "%" : ""}`;
+    text = `Warning: indicator base value achieves ${maxOrMin} coverage (${targetText}) within projection period: population results may fall to zero` ;
+
+    return text;
 }

--- a/model.js
+++ b/model.js
@@ -1207,10 +1207,10 @@ function getCoverageSaturationWarningText(outcomeObject)
     var hasWarning = false;
 
     if (outcomeObject.hasOwnProperty("isNegativeDeltaImprovement") && outcomeObject.isNegativeDeltaImprovement){
-	    var maxOrMin = "minimum";
+        maxOrMin = "minimum";
     }
     else{
-	    var maxOrMin = "maximum";
+        maxOrMin = "maximum";
     }
 
     var targetText = `${outcomeObject.target}${outcomeObject.isPercentage ? "%" : ""}`;


### PR DESCRIPTION
**Background**
It is possible for the observed base data to reach saturation i.e. full coverage; in these cases, the results may be that despite an increase in revenue, there are no people with increased access, since the calculated value cannot exceed saturation. Given that this may be unintuitive for a user, add a text warning to the plot to indicate this.

**Changes**
Add warning text to plot wrapper when observed base coverage reaches saturation.