### PR TITLE
Fix target input being overwritten by call from updateCountries

### DIFF
--- a/grade.js
+++ b/grade.js
@@ -995,7 +995,6 @@ function updatetarget(){
     var text = makeTextTarget(+year, country, outcome, target, getRevenueInputs());
     d3.select("#targetText")
     .html(text);
-    set_outcome_target();
 }
 
 function download_csv(_year, _years_to_project, _countries, _outcomes, _revenue, _governance, _smooth) {


### PR DESCRIPTION
**Background**
Fix for bug whereby target input did not reflect user input, despite result changing

**Changes**
Prevent overwrite by removing unnecessary update call.