### PR TITLE
Allow for spaces in ISO field in revenue CSV files

### DIFF
--- a/grade.js
+++ b/grade.js
@@ -745,7 +745,7 @@ function setupMenus(_countries, _outcomes) {
             
             e.year   = +d.YEAR;
             e.REVENUE = str2Num(d.REVENUE);
-            e.ISO = d.ISO;
+            e.ISO = d.ISO.trim();
             
             return e;
         }


### PR DESCRIPTION
## Background
Fix for #29 

## Changes
Allow for whitespace in ISO field of uploaded revenue CSV file

## Testing
Developer tested