### PR TITLE
Bugfix transform limits for working var

### DIFF
--- a/model.js
+++ b/model.js
@@ -817,13 +817,13 @@ var outcomesList = [
             
             loCol: "#dee5f8",
 	    hiCol: "#e09900",            
-	    fixedExtent: [0,20],
+	    fixedExtent: [0,30],
             desc: "Nurses (per 1,000 people)",
             isStockVar : true,
             isInterpolated : false,
             isPercentage: false,
 	    isStandardPopulationIndicator: false,
-            target:20,
+            target:30,
 	    dp:4,
             fn :    function(_grpc, _iso, _year, _gov) { 
                 g = _type => getGov(_type, _iso, _year, _gov, _grpc);


### PR DESCRIPTION
## Background
Fix for #33. The upper limit thresholding was being applied incorrectly for indicators which use a transformed working variable. Here this problem is fixed. 

## Changes
- Transform the limit before it is applied to the working variable;
- increase the limit for nurses to encompass observations;
- tidy up local vars.

## Testing
Developer tested by plotting improved coverage, increasing revenue arbitrarily, and confirming that limits are respected.