### PR TITLE
Projection fix and improvements

### DIFF
--- a/projection.js
+++ b/projection.js
@@ -56,12 +56,20 @@ function getProjectionData(
       _governance.table = NaN;
     } else {
       var grpcIncreaseFactor = 1 + startRevenue['percentage increase'];
-      _governance.table = forecastGovernance(
-        _country,
-        _firstyear,
-        years_to_project + 1,
-        grpcIncreaseFactor,
-      );
+      // If there is effectively no revenue change, don't run the endogenous
+      // governance forecast — use observed governance values instead.
+      // This prevents small forecasting/residual differences altering the baseline
+      // when additional revenue is zero.
+      if (Math.abs(startRevenue['percentage increase']) < 1e-12) {
+        _governance.table = null;
+      } else {
+        _governance.table = forecastGovernance(
+          _country,
+          _firstyear,
+          years_to_project + 1,
+          grpcIncreaseFactor,
+        );
+      }
     }
   }
 

--- a/projection.js
+++ b/projection.js
@@ -198,12 +198,17 @@ function getProjectionData(
 
     for (let i = 1; i < years_to_smooth; i++) {
       for (const property_index in ret.data[i].additional) {
-        const start_value = ret.data[0].additional[property_index].value;
-        const end_value =
-          ret.data[years_to_wait].additional[property_index].value;
-        const interpolated_value =
-          start_value + (i * (end_value - start_value)) / years_to_wait;
-        datacopy[i].additional[property_index].value = interpolated_value;
+        const propertyName = ret.data[0].additional[property_index].name;
+        // Hack to avoid smoothing the only two additional results which are base values derived/computed from base data
+        if (propertyName != 'Under-5 deaths' && propertyName != 'Maternal deaths' )
+	{
+          const start_value = ret.data[0].additional[property_index].value;
+          const end_value =
+            ret.data[years_to_wait].additional[property_index].value;
+          const interpolated_value =
+              start_value + (i * (end_value - start_value)) / years_to_wait;
+          datacopy[i].additional[property_index].value = interpolated_value;
+	}
       }
     }
     // ...and use it to replace the data already in place


### PR DESCRIPTION
## Background
Testing carried out on the latest data update revealed a bug as described in #41. Work to identify the root cause also identified a small improvement to be made in calculation of the governance values.

## Changes
- Avoid smoothing additional results which are actually base data results (observed under-5 and maternal deaths), i.e. these values are not present in the base data, so they are derived from it.
- Avoid calculating governance when the change in revenue is below tolerance.

## Testing
Tested by comparing under-5 and maternal deaths between both models for CAR for 2015-2020 with zero additional revenue, with smoothing on.